### PR TITLE
Use `forge-std/console2.sol`

### DIFF
--- a/solidity/test/utils/DSTestFull.sol
+++ b/solidity/test/utils/DSTestFull.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.4 <0.9.0;
 
-import 'forge-std/console.sol';
+import 'forge-std/console2.sol';
 import 'prb/test/PRBTest.sol';
 
 contract DSTestFull is PRBTest {


### PR DESCRIPTION
Use `forge-std/console2.sol` instead of `forge-std/console.sol`
In [forge-std](https://book.getfoundry.sh/forge/forge-std) readme from foundry book they recommend use console2
> Note: console2.sol contains patches to console.sol that allows Forge to decode traces for calls to the console, but it is not compatible with Hardhat.
Source