### PR TITLE
feat: modify gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 yarn-error.log
 node_modules
 .DS_STORE
+.vscode
 
 # Foundry files
 cache


### PR DESCRIPTION
Switching local solidity version causes a creation of the `.vscode` config. Adding it in the gitignore would be nice