### PR TITLE
fix: apply separate rules for src and tests with `lint-staged`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "lint-staged": {
     "*.{js,css,md,ts,sol}": "forge fmt",
-    "*.sol": "solhint --fix './(src|test|script)/**/*.sol",
+    "(src|script)/**/*.sol": "yarn lint:sol-logic",
+    "test/**/*.sol": "yarn lint:sol-tests",
     "package.json": "sort-package-json"
   },
   "dependencies": {


### PR DESCRIPTION
From @0xAustrian 🐯:
> When trying to commit some tests files, the pre-commit execution was failing because of some lint warning and errors in the test file, while the `yarn lint:fix` command was successful with no warnings.