### PR TITLE
feat: add max line length solhint rule

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -12,6 +12,7 @@
     "ordering": "warn",
     "immutable-name-snakecase": "warn",
     "avoid-low-level-calls": "off",
-    "no-console": "off"
+    "no-console": "off",
+    "max-line-length": ["warn", 120]
   }
 }

--- a/.solhint.tests.json
+++ b/.solhint.tests.json
@@ -19,6 +19,7 @@
     "ordering": "warn",
     "immutable-name-snakecase": "warn",
     "avoid-low-level-calls": "off",
-    "one-contract-per-file": "off"
+    "one-contract-per-file": "off",
+    "max-line-length": ["warn", 120]
   }
 }


### PR DESCRIPTION
Added `max-line-length` solhint rule. Docs reference [here](https://protofire.github.io/solhint/docs/rules/best-practises/max-line-length.html).
There is a rule for 120 max line length in the `foundry.toml` file, but this rule only applies for Solidity code. With this addition Natspec comments will also be matched. 