### PR TITLE
test: halmos stress test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ yarn-error.log
 node_modules
 .DS_STORE
 .vscode
+.python-version
 
 # Foundry files
 cache

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:sol-tests": "solhint -c .solhint.tests.json 'test/**/*.sol'",
     "prepare": "husky install",
     "test": "forge test -vvv",
-    "test:fuzz": "echidna test/invariants/fuzz/Greeter.t.sol --contract GreeterInvariant --corpus-dir test/invariants/fuzz/echidna_coverage/ --test-mode assertion",
+    "test:fuzz": "echidna test/invariants/fuzz/Greeter.t.sol --contract InvariantGreeter --corpus-dir test/invariants/fuzz/echidna_coverage/ --test-mode assertion",
     "test:integration": "forge test --match-contract Integration -vvv",
     "test:symbolic": "halmos",
     "test:unit": "forge test --match-contract Unit -vvv",

--- a/src/contracts/Greeter.sol
+++ b/src/contracts/Greeter.sol
@@ -6,10 +6,16 @@ import {IGreeter} from 'interfaces/IGreeter.sol';
 
 contract Greeter is IGreeter {
   /**
-   * @notice Empty string for revert checks
+   * @notice Empty string signature for revert checks
    * @dev result of doing keccak256(bytes(''))
    */
   bytes32 internal constant _EMPTY_STRING = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
+
+  /**
+   * @notice Forbidden string signature for revert checks
+   * @dev result of doing keccak256(bytes('SECRET_STRING'))
+   */
+  bytes32 internal constant _FORBIDDEN_STRING = 0x8c917c6c6ed13e2a7bc9a85e333804f00ef06bf49d17d1140551e128758a022c;
 
   /// @inheritdoc IGreeter
   address public immutable OWNER;
@@ -49,7 +55,8 @@ contract Greeter is IGreeter {
 
   /// @inheritdoc IGreeter
   function setGreeting(string memory _greeting) public onlyOwner {
-    if (keccak256(bytes(_greeting)) == _EMPTY_STRING) {
+    bytes32 _greetingHash = keccak256(bytes(_greeting));
+    if (_greetingHash == _EMPTY_STRING || _greetingHash == _FORBIDDEN_STRING) {
       revert Greeter_InvalidGreeting();
     }
 


### PR DESCRIPTION
results from `yarn test:symbolic`:
```ts
Counterexample: 
    halmos_initial_greeting_string_01 = ""
    halmos_new_greeting_string_03 = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
    p__caller_address = 0x00000000000000000000000000000000aaaa0001

[FAIL] check_setGreeting_onlyOwnerSetsGreeting(address) (paths: 5, time: 0.13s, bounds: [])
[PASS] check_validState_greeterNeverEmpty(address) (paths: 8, time: 0.85s, bounds: [])
```