### PR TITLE
chore: bump natspec smells version and update config file

### DIFF
--- a/natspec-smells.config.js
+++ b/natspec-smells.config.js
@@ -4,5 +4,6 @@
 
 /** @type {import('@defi-wonderland/natspec-smells').Config} */
 module.exports = {
-  include: 'src'
+  include: 'src/**/*.sol',
+  exclude: '(test|scripts)/**/*.sol',
 };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@commitlint/cli": "19.3.0",
     "@commitlint/config-conventional": "19.2.2",
-    "@defi-wonderland/natspec-smells": "1.1.1",
+    "@defi-wonderland/natspec-smells": "1.1.3",
     "forge-std": "github:foundry-rs/forge-std#1.8.2",
     "halmos-cheatcodes": "github:a16z/halmos-cheatcodes#c0d8655",
     "husky": ">=8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -181,13 +181,13 @@
     "@types/conventional-commits-parser" "^5.0.0"
     chalk "^5.3.0"
 
-"@defi-wonderland/natspec-smells@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@defi-wonderland/natspec-smells/-/natspec-smells-1.1.1.tgz#1eed85765ebe4799f8861247308d6365dbf6dbaa"
-  integrity sha512-vtOKN4j32Rxl8c1txXxs/iDlkPRmrL/UzUYWOzowe1HYH8ioPMRrsKAYVriDBLsvSi2bY06Sl3cN9SQJSbVzsA==
+"@defi-wonderland/natspec-smells@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@defi-wonderland/natspec-smells/-/natspec-smells-1.1.3.tgz#6d4c7e289b24264856170fec33e0cae0c844bd32"
+  integrity sha512-QfZ7uD2bseU/QwQgY8uFrGSD5+a4y1S+GqCNePfmjgRGnEaV7zSFL5FO+zd1GUMtWQNGLgSuRknJMu6DEp3njw==
   dependencies:
     fast-glob "3.3.2"
-    solc-typed-ast "18.1.2"
+    solc-typed-ast "18.1.6"
     yargs "17.7.2"
 
 "@noble/curves@1.3.0", "@noble/curves@~1.3.0":
@@ -375,10 +375,10 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^1.6.7:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.1.tgz#522145622a09dfaf49359837db9649ff245a35b9"
-  integrity sha512-+LV37nQcd1EpFalkXksWNBiA17NZ5m5/WspmHGmZmdx1qBOg/VNq/c4eRJiA9VQQHBOs+N0ZhhdU10h2TyNK7Q==
+axios@^1.6.8:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.2.tgz#b625db8a7051fbea61c35a3cbb3a1daa7b9c7621"
+  integrity sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"
@@ -1647,26 +1647,26 @@ slice-ansi@^7.0.0:
     ansi-styles "^6.2.1"
     is-fullwidth-code-point "^5.0.0"
 
-solc-typed-ast@18.1.2:
-  version "18.1.2"
-  resolved "https://registry.yarnpkg.com/solc-typed-ast/-/solc-typed-ast-18.1.2.tgz#bc958fe3aead765cf6c2e06ce3d53c61fd06e70c"
-  integrity sha512-57IKzvXHcyjqdjHEdX7NQuWkPALlH8V4eJ6UUehWrzgHDVzKVOCFplwgLDRnOZ8kDMO8+Ms8sQhfrivFK+v5FA==
+solc-typed-ast@18.1.6:
+  version "18.1.6"
+  resolved "https://registry.yarnpkg.com/solc-typed-ast/-/solc-typed-ast-18.1.6.tgz#997e986583f0fdddb3ddb1960c33d5c63b3f729a"
+  integrity sha512-nBk24fdju+P2xsy32tG6HLqkXI+Tn+W84Fqm5+XD1Xby2/8YLlsMgI3ADoRPhhO7DeWjq/kflm//dGNkEb3ILA==
   dependencies:
-    axios "^1.6.7"
+    axios "^1.6.8"
     commander "^12.0.0"
     decimal.js "^10.4.3"
     findup-sync "^5.0.0"
     fs-extra "^11.2.0"
     jsel "^1.1.6"
     semver "^7.6.0"
-    solc "0.8.24"
+    solc "0.8.25"
     src-location "^1.1.0"
     web3-eth-abi "^4.2.0"
 
-solc@0.8.24:
-  version "0.8.24"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.24.tgz#6e5693d28208d00a20ff2bdabc1dec85a5329bbb"
-  integrity sha512-G5yUqjTUPc8Np74sCFwfsevhBPlUifUOfhYrgyu6CmYlC6feSw0YS6eZW47XDT23k3JYdKx5nJ+Q7whCEmNcoA==
+solc@0.8.25:
+  version "0.8.25"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.25.tgz#393f3101617388fb4ba2a58c5b03ab02678e375c"
+  integrity sha512-7P0TF8gPeudl1Ko3RGkyY6XVCxe2SdD/qQhtns1vl3yAbK/PDifKDLHGtx1t7mX3LgR7ojV7Fg/Kc6Q9D2T8UQ==
   dependencies:
     command-exists "^1.2.8"
     commander "^8.1.0"


### PR DESCRIPTION
## This PR introduces the following changes:
- updated `@defi-wonderland/natspec-smells` to latest version
- updated `natspec-smells.config.js` to work out of the box with latest version