### PR TITLE
fix: halmos CI step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v5
         with:
-          python-version: ">=3.9"
+          python-version: "3.10"
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,6 +87,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ">=3.9"
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -97,6 +102,9 @@ jobs:
         with:
           node-version: 20.x
           cache: 'yarn'
+
+      - name: Install halmos
+        run: pip install halmos
 
       - name: Install dependencies
         run: yarn --frozen-lockfile --network-concurrency 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,7 +105,7 @@ jobs:
         run: yarn build
 
       - name: Run tests
-        run: yarn test:integration
+        run: yarn test:symbolic
 
   lint:
     name: Lint Commit Messages


### PR DESCRIPTION
Fixing the halmos CI step that was executing the integration tests instead of the halmos tests.

**Note:** the step is now using `python 3.10` in order to install `halmos 0.1.13`. If a newer version of halmos is required, the python version must be updated. For example: `halmos 0.2.6` [requires](https://pypi.org/project/halmos/0.2.6/) `python 3.11` but those changes break the current tests.