### PR TITLE
feat: run slither-mutate in CI

### DIFF
--- a/.github/scripts/mutate-contract
+++ b/.github/scripts/mutate-contract
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -e
+
+# mutate-contract
+#
+# Wrapper around slither-mutate to perform mutation testing on a provided solidity contract.
+#
+# Usage:
+# ./slither-mutate-on-changed-files [CONTRACT_NAME]
+#
+# Arguments:
+# CONTRACT_NAME  - Name of the contract file to mutate. This is a mandatory argument.
+#
+# Environment Variables:
+# VERBOSE - If set, the script outputs additional debugging information.
+#
+# Exit codes:
+# 255 - No contract name was provided or the contract file couldn't be found.
+#   1 - One or more mutants survived the mutation testing.
+#   0 - Successful mutation testing campaign with all mutants caught.
+
+if [ -z "$1" ] ; then
+    echo "specify what contract to mutate as a command line argument"
+    exit 255
+fi
+
+tempfile="$(mktemp)"
+foundry_sources="$(forge config --json | jq -r .src)"
+find_regex=".*\b$1.sol"
+contract_test="Unit$1"
+contract_file="$(find "${foundry_sources}" -regex "${find_regex}" )"
+
+if [ -z "${contract_file}" ] ; then
+    echo "couldnt find source file for $1 with regex ${find_regex}"
+    exit 255
+fi
+
+if [ -n "$VERBOSE" ] ; then
+    echo "find_regex ${find_regex}"
+    echo "contract_test ${contract_test}"
+    echo "contract_file ${contract_file}"
+    echo "tempfile ${tempfile}"
+fi
+
+# RR: replace a statement with revert()
+# CR: comment a statement out
+slither-mutate "${contract_file}" --test-cmd "forge test --match-contract ${contract_test}" --mutators-to-run RR,CR 2> "$tempfile"
+
+# grep -q: exits successfully on any match, necessary because slither-mutate returns zero even if it finds mutants
+# yes, the above will have a false positive when the UNCAUGHT text appears on a report by any other reason 
+# https://github.com/crytic/slither/issues/2772
+if grep -q UNCAUGHT "$tempfile" ; then
+    [ -n "$VERBOSE" ] && cat "$tempfile"
+    exit 1
+fi

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -1,0 +1,46 @@
+name: slither-mutate
+
+on:
+  workflow_dispatch:
+    inputs:
+      contract:
+        description: 'Contract name to mutate (e.g. Greeter)'
+        required: true
+      ref:
+        description: 'git reference (branch/commit) to check out'
+        required: true
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
+jobs:
+  slither-analyze:
+    name: Run unit tests aganinst mutated contract
+    runs-on: ubuntu-latest
+    container: ghcr.io/trailofbits/eth-security-toolbox/ci:nightly
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile --network-concurrency 1
+
+      - name: Precompile
+        run: yarn build
+
+      - name: Run tests
+        shell: bash
+        run: .github/scripts/mutate-contract ${{ github.event.inputs.contract }}


### PR DESCRIPTION
Run slither mutate on modified contracts

## Objective
Ensure the test quality remains high while saving reviewer time. Comment and revert mutants should *always* be caught by unit tests

## Outstanding work
- [x] workflow for mutating a contract manually
- [ ] workflow to mutate contracts modified in a given PR
    - [ ] figure out what contracts were modified: should be something like `git diff ${basebranch} $(forge config --json |jq -r .src)`
    - [ ] run `slither-mutate` on every one of them
    - [ ] guarantee `forge --mc Unit$1` will actually match the unit tests for the contract. This will be the hardest part, needing some tool (slippy? slang? Very Advanced Solhint?) to ensure:
        - [ ] `src/whatever/Contract.sol` includes `contract Contract` and doesn't include any other contract definition
        - [ ] `UnitContract` actually tests `Contract` (can probably be enforced by adding some restrictions on the names of the trees in `Contract.tree`)

