### PR TITLE
chore: updates coverage GH action to compare coverage against base branch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      base-coverage: ${{ steps.export-base.outputs.base-coverage }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -35,27 +37,31 @@ jobs:
         id: cache-base
         uses: actions/cache@v4
         with:
-          path: .coverage-base/lcov.info
+          path: total-coverage.txt
           key: coverage-base-${{ github.event.pull_request.base.sha }}
 
       - name: Run base branch coverage
         if: steps.cache-base.outputs.cache-hit != 'true'
         run: yarn coverage
 
-      - name: Prepare cached base lcov
+      - name: Setup LCOV (for base coverage summary)
+        if: steps.cache-base.outputs.cache-hit != 'true'
+        uses: hrishikesh-kadam/setup-lcov@v1
+
+      - name: Prepare cached base total coverage
         if: steps.cache-base.outputs.cache-hit != 'true'
         run: |
-          mkdir -p .coverage-base
-          cp lcov.info .coverage-base/lcov.info
+          total_coverage=$(lcov --summary lcov.info 2>/dev/null | awk '/lines\.+:/ {print $2}' | tr -d '%')
+          echo "$total_coverage" > total-coverage.txt
 
-      - name: Copy artifact file
-        run: cp .coverage-base/lcov.info base-lcov.info
-
-      - name: Upload base lcov as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: base-lcov
-          path: base-lcov.info
+      - name: Export base coverage output
+        id: export-base
+        run: |
+          base=0
+          if [ -f total-coverage.txt ]; then
+            base=$(cat total-coverage.txt | tr -d '%')
+          fi
+          echo "base-coverage=$base" >> "$GITHUB_OUTPUT"
 
   check-coverage:
     name: Check PR coverage
@@ -81,24 +87,21 @@ jobs:
       - name: Install dependencies
         run: yarn --frozen-lockfile
 
-      - name: Download base lcov artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: base-lcov
-          path: .
-
-      - name: Normalize base lcov path
-        run: |
-          mkdir -p .coverage-base
-          if [ -f base-lcov.info ]; then
-            cp base-lcov.info .coverage-base/lcov.info
-          fi
-
       - name: Run current branch coverage
         run: yarn coverage
 
-      - name: Setup LCOV
+      - name: Setup LCOV (for current PR coverage summary)
         uses: hrishikesh-kadam/setup-lcov@v1
+
+      - name: Compute minimum coverage threshold
+        id: compute-min
+        run: |
+          base="${{ needs.base-coverage.outputs.base-coverage }}"
+          sens="${{ env.COVERAGE_SENSITIVITY_PERCENT }}"
+          [ -z "$base" ] && base=0
+          [ -z "$sens" ] && sens=0
+          min=$(awk -v b="$base" -v s="$sens" 'BEGIN{v=b-s; if (v<0) v=0; printf "%.2f", v}')
+          echo "minimum=$min" >> "$GITHUB_OUTPUT"
 
       # Updates the comment on every PR push
       - name: Create a comment on the PR with the current branch coverage
@@ -109,17 +112,4 @@ jobs:
           coverage-files: lcov.info
           github-token: ${{ github.token }}
           update-comment: true
-
-      - name: Compare previous coverage (against base branch)
-        run: |
-          if [ -f .coverage-base/lcov.info ]; then
-            old=$(lcov --summary .coverage-base/lcov.info 2>/dev/null | awk '/lines\.+:/ {print $2}' | tr -d '%')
-          else
-            old=0
-          fi
-          head="${{ steps.new-coverage.outputs.total-coverage }}"
-          [ -z "$head" ] && head=0
-          new=$(awk -v a="$head" -v b="${{ env.COVERAGE_SENSITIVITY_PERCENT }}" 'BEGIN{printf "%.2f", a+b}')
-          if awk "BEGIN {exit !($new < $old)}"; then
-            echo "Coverage decreased from $old to $new"; exit 1
-          fi
+          minimum-coverage: ${{ steps.compute-min.outputs.minimum }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,8 +5,6 @@ on:
 
 env:
   COVERAGE_SENSITIVITY_PERCENT: 1
-  MAINNET_RPC: ${{ secrets.MAINNET_RPC }}
-  SEPOLIA_RPC: ${{ secrets.SEPOLIA_RPC }}
 
 jobs:
   base-coverage:
@@ -89,6 +87,13 @@ jobs:
           name: base-lcov
           path: .
 
+      - name: Normalize base lcov path
+        run: |
+          mkdir -p .coverage-base
+          if [ -f base-lcov.info ]; then
+            cp base-lcov.info .coverage-base/lcov.info
+          fi
+
       - name: Run current branch coverage
         run: yarn coverage
 
@@ -98,6 +103,7 @@ jobs:
       # Updates the comment on every PR push
       - name: Create a comment on the PR with the current branch coverage
         id: new-coverage
+        if: hashFiles('lcov.info') != ''
         uses: zgosalvez/github-actions-report-lcov@v4
         with:
           coverage-files: lcov.info
@@ -106,14 +112,14 @@ jobs:
 
       - name: Compare previous coverage (against base branch)
         run: |
-          if [ -f base-lcov.info ]; then
-            old=$(lcov --summary base-lcov.info 2>/dev/null | awk '/lines\.+:/ {print $2}' | tr -d '%')
+          if [ -f .coverage-base/lcov.info ]; then
+            old=$(lcov --summary .coverage-base/lcov.info 2>/dev/null | awk '/lines\.+:/ {print $2}' | tr -d '%')
           else
             old=0
           fi
-          new_total=${{ steps.new-coverage.outputs.total-coverage }}
-          new=$(awk -v a="$new_total" -v b="${{ env.COVERAGE_SENSITIVITY_PERCENT }}" 'BEGIN{printf "%.2f", a+b}')
+          head="${{ steps.new-coverage.outputs.total-coverage }}"
+          [ -z "$head" ] && head=0
+          new=$(awk -v a="$head" -v b="${{ env.COVERAGE_SENSITIVITY_PERCENT }}" 'BEGIN{printf "%.2f", a+b}')
           if awk "BEGIN {exit !($new < $old)}"; then
-            echo "Coverage decreased from $old to $new"
-            exit 1
+            echo "Coverage decreased from $old to $new"; exit 1
           fi

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,17 +1,23 @@
 name: Coverage Check
 
-on: [push]
+on:
+  pull_request:
 
 env:
   COVERAGE_SENSITIVITY_PERCENT: 1
+  MAINNET_RPC: ${{ secrets.MAINNET_RPC }}
+  SEPOLIA_RPC: ${{ secrets.SEPOLIA_RPC }}
 
 jobs:
-  upload-coverage:
-    name: Upload Coverage
+  base-coverage:
+    name: Generate base coverage
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -22,52 +28,92 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: 'yarn'
+          cache: "yarn"
 
       - name: Install dependencies
-        run: yarn --frozen-lockfile --network-concurrency 1
+        run: yarn --frozen-lockfile
 
-      - name: Run coverage
-        shell: bash
+      - name: Restore base coverage cache
+        id: cache-base
+        uses: actions/cache@v4
+        with:
+          path: .coverage-base/lcov.info
+          key: coverage-base-${{ github.event.pull_request.base.sha }}
+
+      - name: Run base branch coverage
+        if: steps.cache-base.outputs.cache-hit != 'true'
+        run: yarn coverage
+
+      - name: Prepare cached base lcov
+        if: steps.cache-base.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p .coverage-base
+          cp lcov.info .coverage-base/lcov.info
+
+      - name: Copy artifact file
+        run: cp .coverage-base/lcov.info base-lcov.info
+
+      - name: Upload base lcov as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: base-lcov
+          path: base-lcov.info
+
+  check-coverage:
+    name: Check PR coverage
+    runs-on: ubuntu-latest
+    needs: base-coverage
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Download base lcov artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: base-lcov
+          path: .
+
+      - name: Run current branch coverage
         run: yarn coverage
 
       - name: Setup LCOV
         uses: hrishikesh-kadam/setup-lcov@v1
 
-      - name: Filter directories
-        run: lcov --remove lcov.info 'test/*' 'script/*' --output-file lcovNew.info --rc branch_coverage=1 --rc derive_function_end_line=0 --ignore-errors unused
-
-      - name: Capture coverage output
+      # Updates the comment on every PR push
+      - name: Create a comment on the PR with the current branch coverage
         id: new-coverage
         uses: zgosalvez/github-actions-report-lcov@v4
         with:
-          coverage-files: lcovNew.info
+          coverage-files: lcov.info
+          github-token: ${{ github.token }}
+          update-comment: true
 
-      - name: Retrieve previous coverage
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage.info
-        continue-on-error: true
-
-      - name: Check if a previous coverage exists
+      - name: Compare previous coverage (against base branch)
         run: |
-          if [ ! -f coverage.info ]; then
-            echo "Artifact not found. Initializing at 0"
-            echo "0" >> coverage.info
+          if [ -f base-lcov.info ]; then
+            old=$(lcov --summary base-lcov.info 2>/dev/null | awk '/lines\.+:/ {print $2}' | tr -d '%')
+          else
+            old=0
           fi
-
-      - name: Compare previous coverage
-        run: |
-          old=$(cat coverage.info)
-          new=$(( ${{ steps.new-coverage.outputs.total-coverage }} + ${{ env.COVERAGE_SENSITIVITY_PERCENT }} ))
-          if [ "$new" -lt "$old" ]; then
+          new_total=${{ steps.new-coverage.outputs.total-coverage }}
+          new=$(awk -v a="$new_total" -v b="${{ env.COVERAGE_SENSITIVITY_PERCENT }}" 'BEGIN{printf "%.2f", a+b}')
+          if awk "BEGIN {exit !($new < $old)}"; then
             echo "Coverage decreased from $old to $new"
             exit 1
           fi
-          mv lcovNew.info coverage.info
-
-      - name: Upload the new coverage
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage.info
-          path: ./coverage.info


### PR DESCRIPTION
1- When the PR is created, it runs the coverage in the base branch and caches result
2- With every push it calculates the coverage in the current PR and creates a comment with coverage information. This comment is updated every time there is a new push.
<img width="929" height="312" alt="image" src="https://github.com/user-attachments/assets/25dd45c3-170d-4865-9b03-b9f50fa6305d" />

3- It compares the total coverage from the base branch and the new push. If the coverages decreases in the new push, a the comment is updated and the build fails

<img width="955" height="354" alt="image" src="https://github.com/user-attachments/assets/dae1a24e-5920-4133-b7b8-329f2b18728b" />

Note: yarn coverage only runs unit tests to avoid killing the RPC with fuzz tests
Note: It uses a sensitivity factor, otherwise the coverage fails even if nothing changes.

Closes BES-2