### PR TITLE
chore: add relevant invariant setting

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,6 +9,7 @@ multiline_func_header = 'params_first_multi'
 sort_imports = true
 
 [invariant]
+corpus_dir='cache/corpus'
 show_solidity=true
 
 [profile.default]

--- a/foundry.toml
+++ b/foundry.toml
@@ -8,6 +8,9 @@ number_underscore = 'thousands'
 multiline_func_header = 'params_first_multi'
 sort_imports = true
 
+[invariant]
+show_solidity=true
+
 [profile.default]
 solc_version = '0.8.23'
 libs = ['node_modules', 'lib']


### PR DESCRIPTION
this will cause foundry to output invariant testing counterexamples as solidity code that can be pasted into a unit test instead of the raw parameters. Related to https://github.com/defi-wonderland/youdusa-rs/pull/29