### PR TITLE
fix: using correct tag of forge-std & integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@commitlint/cli": "19.3.0",
     "@commitlint/config-conventional": "19.2.2",
-    "forge-std": "github:foundry-rs/forge-std#1.9.2",
+    "forge-std": "github:foundry-rs/forge-std#v1.9.2",
     "husky": ">=9",
     "lint-staged": ">=16",
     "solhint-community": "4.0.1",

--- a/test/integration/IntegrationBase.sol
+++ b/test/integration/IntegrationBase.sol
@@ -6,8 +6,6 @@ import {Test} from 'forge-std/Test.sol';
 import {IERC20} from 'forge-std/interfaces/IERC20.sol';
 
 contract IntegrationBase is Test {
-  uint256 internal constant _FORK_BLOCK = 18_920_905;
-
   string internal _initialGreeting = 'hola';
   address internal _user = makeAddr('user');
   address internal _owner = makeAddr('owner');
@@ -16,7 +14,7 @@ contract IntegrationBase is Test {
   IGreeter internal _greeter;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), _FORK_BLOCK);
+    vm.createSelectFork(vm.rpcUrl('mainnet'));
     vm.prank(_owner);
     _greeter = new Greeter(_initialGreeting, _dai);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -593,7 +593,7 @@ find-up@^7.0.0:
     path-exists "^5.0.0"
     unicorn-magic "^0.1.0"
 
-"forge-std@github:foundry-rs/forge-std#1.9.2":
+"forge-std@github:foundry-rs/forge-std#v1.9.2":
   version "1.9.2"
   resolved "https://codeload.github.com/foundry-rs/forge-std/tar.gz/1714bee72e286e73f76e320d110e0eaf5c4e649d"
 


### PR DESCRIPTION
While `yarn install` worked fine, pnpm's stricter git dependency resolution required the exact tag name. Also, integration tests were failing due to the block #18920906 already being pruned.

### Solution
Updated the forge-std dependency reference from `#1.9.2` to `#v1.9.2` to match the actual tag naming convention in the foundry-rs/forge-std repository.

Removed the block specificity from the integration test altogether, to avoid having this problem in the future yet again.

### Result
Both yarn and pnpm can now successfully resolve and install dependencies, and all tests are passing.