### PR TITLE
fix: broken ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,6 @@ jobs:
           fetch-depth: 0
 
       - uses: wagoid/commitlint-github-action@v5
-
       - name: install-tools
         uses: ./.github/workflows/install-tools
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,6 @@ jobs:
         run: yarn lint:check
 
       - name: Install and run Bulloak
-        uses: smol-ninja/bulloak-toolchain@v1
+        uses: smol-ninja/bulloak-toolchain@v2
         with:
           test-dir: 'test/unit'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,3 +60,4 @@ jobs:
         uses: smol-ninja/bulloak-toolchain@v2
         with:
           test-dir: 'test/unit'
+          version: '0.8.1'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
         run: yarn lint:check
 
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install and run Bulloak
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,9 +49,9 @@ jobs:
           fetch-depth: 0
 
       - uses: wagoid/commitlint-github-action@v5
+
       - name: install-tools
         uses: ./.github/workflows/install-tools
-
 
       - name: Run Forge formatter and Solhint
         run: yarn lint:check
@@ -60,6 +60,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install and run Bulloak
-        run:  uses: smol-ninja/bulloak-toolchain@v1
+        uses: smol-ninja/bulloak-toolchain@v1
         with:
           test-dir: 'test/unit'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,9 +56,6 @@ jobs:
       - name: Run Forge formatter and Solhint
         run: yarn lint:check
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Install and run Bulloak
         uses: smol-ninja/bulloak-toolchain@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,5 +61,5 @@ jobs:
 
       - name: Install and run Bulloak
         run: |
-          cargo install --git https://github.com/0xChin/bulloak bulloak
+          cargo install --git https://github.com/0xChin/bulloak --branch chore/solang-forge-fmt-migration bulloak
           bulloak check --skip-modifiers test/unit/**/*.tree

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,8 +56,10 @@ jobs:
       - name: Run Forge formatter and Solhint
         run: yarn lint:check
 
+      - name: Install Rust
+        uses: dtolnay/rust-action@stable
+
       - name: Install and run Bulloak
-        uses: smol-ninja/bulloak-toolchain@v2
-        with:
-          test-dir: 'test/unit'
-          version: '0.8.1'
+        run: |
+          cargo install --git https://github.com/0xChin/bulloak bulloak
+          bulloak check --skip-modifiers test/unit/**/*.tree

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install and run Bulloak
-        run: |
-          cargo install --git https://github.com/0xChin/bulloak --branch chore/solang-forge-fmt-migration bulloak
-          bulloak check --skip-modifiers test/unit/**/*.tree
+        run:  uses: smol-ninja/bulloak-toolchain@v1
+        with:
+          test-dir: 'test/unit'

--- a/test/integration/IntegrationBase.sol
+++ b/test/integration/IntegrationBase.sol
@@ -6,7 +6,7 @@ import {Test} from 'forge-std/Test.sol';
 import {IERC20} from 'forge-std/interfaces/IERC20.sol';
 
 contract IntegrationBase is Test {
-  uint256 internal constant _FORK_BLOCK = 18_920_905;
+  uint256 internal constant _FORK_BLOCK = 24_213_086;
 
   string internal _initialGreeting = 'hola';
   address internal _user = makeAddr('user');


### PR DESCRIPTION
1. The integrations are fixed by increasing the block number, given that we were using a very old one
2. The static analysis was failing because bulloak had a bugged dependency since solidity 0.8.31 was launched. I'm currently using a fork https://github.com/0xChin/bulloak, and will open a PR to their repo fixing the issue (if they agree to use it). The fix includes a migration from a deprecated dependency: [forge_fmt](https://github.com/alexfertel/bulloak/blob/main/Cargo.toml#L43) which depends on the archived repository [ethers-rs](https://github.com/gakonst/ethers-rs) to [solang-forge-fmt](https://crates.io/crates/solang-forge-fmt/0.2.0), a fork of forge-fmt that is mantained by foundry contributors.

Keeping it as draft PR until at least we review the migration and best case scenario, having the change merged in the bulloak repo, which would require no changes