### PR TITLE
fix(coverage): make sure test files are not included in coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "forge build",
     "build:optimized": "FOUNDRY_PROFILE=optimized forge build",
-    "coverage": "forge coverage --report summary --report lcov --match-path 'test/unit/*'",
+    "coverage": "forge coverage --report summary --report lcov --match-path 'test/unit/*' --no-match-coverage test",
     "deploy:mainnet": "bash -c 'source .env && forge script Deploy --rpc-url mainnet --account $MAINNET_DEPLOYER_NAME --broadcast --verify --chain mainnet -vvvvv'",
     "deploy:sepolia": "bash -c 'source .env && forge script Deploy --rpc-url sepolia --account $SEPOLIA_DEPLOYER_NAME --broadcast --verify --chain sepolia -vvvvv'",
     "lint:bulloak": "find test/unit -name '*.tree' | xargs bulloak check",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "forge build",
     "build:optimized": "FOUNDRY_PROFILE=optimized forge build",
-    "coverage": "forge coverage --report summary --report lcov --match-path 'test/unit/*' --no-match-coverage test",
+    "coverage": "forge coverage --report summary --report lcov --match-path 'test/unit/*' --no-match-coverage 'test/'",
     "deploy:mainnet": "bash -c 'source .env && forge script Deploy --rpc-url mainnet --account $MAINNET_DEPLOYER_NAME --broadcast --verify --chain mainnet -vvvvv'",
     "deploy:sepolia": "bash -c 'source .env && forge script Deploy --rpc-url sepolia --account $SEPOLIA_DEPLOYER_NAME --broadcast --verify --chain sepolia -vvvvv'",
     "lint:bulloak": "find test/unit -name '*.tree' | xargs bulloak check",


### PR DESCRIPTION
Added --no-match-coverage test to the coverage script so the summary and lcov.info only include files whose path does not match test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude test files from coverage reports by adding --no-match-coverage 'test/' to the forge coverage script, so summary and lcov.info only reflect source files.

<sup>Written for commit 3c5b80fc72a0759487bc9648df5fa5eca0581093. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

